### PR TITLE
Adds linting and pre-commit

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,138 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+    #
+    # You can have as many configs as you like in the `configs:` field.
+    configs: [
+      %{
+        #
+        # Run any config using `mix credo -C <name>`. If no config name is given
+        # "default" is used.
+        name: "default",
+        #
+        # These are the files included in the analysis:
+        files: %{
+          #
+          # You can give explicit globs or simply directories.
+          # In the latter case `**/*.{ex,exs}` will be used.
+          included: ["src/", "web/", "apps/", "test/"],
+          excluded: [~r"/_build/", ~r"/deps/", ~r"/test/support/"]
+        },
+        #
+        # If you create your own checks, you must specify the source files for
+        # them here, so they can be loaded by Credo before running the analysis.
+        requires: [],
+        #
+        # Credo automatically checks for updates, like e.g. Hex does.
+        # You can disable this behaviour below:
+        check_for_updates: true,
+        #
+        # If you want to enforce a style guide and need a more traditional linting
+        # experience, you can change `strict` to `true` below:
+        strict: false,
+        #
+        # If you want to use uncolored output by default, you can change `color`
+        # to `false` below:
+        color: true,
+        #
+        # You can customize the parameters of any check by adding a second element
+        # to the tuple.
+        #
+        # To disable a check put `false` as second element:
+        #
+        #     {Credo.Check.Design.DuplicatedCode, false}
+        #
+        checks: [
+          {Credo.Check.Consistency.ExceptionNames},
+          {Credo.Check.Consistency.LineEndings},
+          {Credo.Check.Consistency.ParameterPatternMatching},
+          {Credo.Check.Consistency.SpaceAroundOperators},
+          {Credo.Check.Consistency.SpaceInParentheses},
+          {Credo.Check.Consistency.TabsOrSpaces},
+  
+          # For some checks, like AliasUsage, you can only customize the priority
+          # Priority values are: `low, normal, high, higher`
+          {Credo.Check.Design.AliasUsage, priority: :low},
+  
+          # For others you can set parameters
+  
+          # If you don't want the `setup` and `test` macro calls in ExUnit tests
+          # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
+          # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
+          {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+  
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          {Credo.Check.Design.TagTODO, exit_status: 2},
+          {Credo.Check.Design.TagFIXME},
+  
+          {Credo.Check.Readability.FunctionNames},
+          {Credo.Check.Readability.LargeNumbers},
+          {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+          {Credo.Check.Readability.ModuleAttributeNames},
+          {Credo.Check.Readability.ModuleDoc},
+          {Credo.Check.Readability.ModuleNames},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
+          {Credo.Check.Readability.ParenthesesInCondition},
+          {Credo.Check.Readability.PredicateFunctionNames},
+          {Credo.Check.Readability.PreferImplicitTry},
+          {Credo.Check.Readability.RedundantBlankLines},
+          {Credo.Check.Readability.StringSigils},
+          {Credo.Check.Readability.TrailingBlankLine},
+          {Credo.Check.Readability.TrailingWhiteSpace},
+          {Credo.Check.Readability.VariableNames},
+          {Credo.Check.Readability.Semicolons},
+          {Credo.Check.Readability.SpaceAfterCommas},
+  
+          {Credo.Check.Refactor.DoubleBooleanNegation},
+          {Credo.Check.Refactor.CondStatements},
+          {Credo.Check.Refactor.CyclomaticComplexity},
+          {Credo.Check.Refactor.FunctionArity},
+          {Credo.Check.Refactor.MatchInCondition},
+          {Credo.Check.Refactor.NegatedConditionsInUnless},
+          {Credo.Check.Refactor.NegatedConditionsWithElse},
+          {Credo.Check.Refactor.Nesting},
+          {Credo.Check.Refactor.PipeChainStart},
+          {Credo.Check.Refactor.UnlessWithElse},
+  
+          {Credo.Check.Warning.BoolOperationOnSameValues},
+          {Credo.Check.Warning.IExPry},
+          {Credo.Check.Warning.IoInspect},
+          {Credo.Check.Warning.LazyLogging},
+          {Credo.Check.Warning.OperationOnSameValues},
+          {Credo.Check.Warning.OperationWithConstantResult},
+          {Credo.Check.Warning.UnusedEnumOperation},
+          {Credo.Check.Warning.UnusedFileOperation},
+          {Credo.Check.Warning.UnusedKeywordOperation},
+          {Credo.Check.Warning.UnusedListOperation},
+          {Credo.Check.Warning.UnusedPathOperation},
+          {Credo.Check.Warning.UnusedRegexOperation},
+          {Credo.Check.Warning.UnusedStringOperation},
+          {Credo.Check.Warning.UnusedTupleOperation},
+  
+          # Controversial and experimental checks (opt-in, just remove `, false`)
+          #
+          {Credo.Check.Refactor.ABCSize, false},
+          {Credo.Check.Refactor.AppendSingleItem, false},
+          {Credo.Check.Refactor.VariableRebinding, false},
+          {Credo.Check.Warning.MapGetUnsafePass, false},
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+  
+          # Deprecated checks (these will be deleted after a grace period)
+          {Credo.Check.Readability.Specs, false},
+          {Credo.Check.Warning.NameRedeclarationByAssignment, false},
+          {Credo.Check.Warning.NameRedeclarationByCase, false},
+          {Credo.Check.Warning.NameRedeclarationByDef, false},
+          {Credo.Check.Warning.NameRedeclarationByFn, false},
+  
+          # Custom checks can be created using `mix credo.gen.check`.
+          #
+        ]
+      }
+    ]
+  }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,5 @@
 use Mix.Config
+
+config :pre_commit,
+    commands: ["test", "credo --strict"],
+    verbose: true

--- a/lib/protect.ex
+++ b/lib/protect.ex
@@ -7,7 +7,6 @@ defmodule Protect do
   require Poison
   alias Protect.Github
 
-
   @doc """
     The function that is called when the command line script is run.
     The arguments are passed in from the command line options.
@@ -27,7 +26,6 @@ defmodule Protect do
     |> report
   end
 
-
   @doc """
     Parses command line arguments into a keyword list.
   """
@@ -37,7 +35,6 @@ defmodule Protect do
     )
     options
   end
-
 
   @doc """
     Checks if the command line options are valid, and throws an error if not.
@@ -68,7 +65,6 @@ defmodule Protect do
     options
   end
 
-
   @doc """
     Gets a list of Github repos for an owner that can be either a user or an
     organisation.
@@ -88,7 +84,6 @@ defmodule Protect do
     end
   end
 
-
   @doc """
     Determines the correct url to use in the get_repos function, depending on
     whether the repo owner is a user or an organisation.
@@ -102,7 +97,6 @@ defmodule Protect do
       end
   end
 
-
   @doc """
     Applies a set of rules to the master branch of the repo specified.
   """
@@ -112,7 +106,6 @@ defmodule Protect do
     "/repos/#{owner}/#{repo}/branches/master/protection"
     |> Github.put!(rules)
   end
-
 
   @doc """
     Reports how many repos were succesfully or unsuccessfully protected.

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,8 @@ defmodule Protect.Mixfile do
   defp deps do
     [
       {:poison, "~> 3.1"},
-      {:httpoison, "~> 0.13.0"}
+      {:httpoison, "~> 0.13.0"},
+      {:credo, "~> 0.8", only: [:dev, :test], runtime: false}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,8 @@ defmodule Protect.Mixfile do
     [
       {:poison, "~> 3.1"},
       {:httpoison, "~> 0.13.0"},
-      {:credo, "~> 0.8", only: [:dev, :test], runtime: false}
+      {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
+      {:pre_commit, "~> 0.2.4", only: :dev}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], []},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [], [], "hexpm"},
+  "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], []},
+  "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.10.1", "c38d0ca52ea80254936a32c45bb7eb414e7a96a521b4ce76d00a69753b157f21", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, optional: false]}, {:idna, "5.1.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.13.0", "bfaf44d9f133a6599886720f3937a7699466d23bb0cd7a88b6ba011f53c6f562", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, optional: false]}]},

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,6 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+  "pre_commit": {:hex, :pre_commit, "0.2.4", "e26feaa149d55d3a6f14ca1340bd8738942d98405de389c0b3c7d48e71e62d66", [], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []}}


### PR DESCRIPTION
Adds linting using credo and [the config from tudo](https://github.com/dwyl/tudo/blob/master/.credo.exs).

Removes excess line breaks to pass linting.

Adds pre-commit hooks using dwyl/elixir-pre-commit, for tests and linting.

fix #4 #3 